### PR TITLE
Drivers: rtc: Fix bit operations in LL_RTC_DATE_Config()

### DIFF
--- a/Drivers/STM32L1xx_HAL_Driver/Inc/stm32l1xx_ll_rtc.h
+++ b/Drivers/STM32L1xx_HAL_Driver/Inc/stm32l1xx_ll_rtc.h
@@ -1564,9 +1564,9 @@ __STATIC_INLINE void LL_RTC_DATE_Config(RTC_TypeDef *RTCx, uint32_t WeekDay, uin
 {
   register uint32_t temp;
 
-  temp = (WeekDay << RTC_DR_WDU_Pos)                                                        | \
+  temp = ((WeekDay & 0x07U) << RTC_DR_WDU_Pos)                                            | \
          (((Year & 0xF0U) << (RTC_DR_YT_Pos - 4U)) | ((Year & 0x0FU) << RTC_DR_YU_Pos))   | \
-         (((Month & 0xF0U) << (RTC_DR_MT_Pos - 4U)) | ((Month & 0x0FU) << RTC_DR_MU_Pos)) | \
+         (((Month & 0x10U) << (RTC_DR_MT_Pos - 4U)) | ((Month & 0x0FU) << RTC_DR_MU_Pos)) | \
          (((Day & 0xF0U) << (RTC_DR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_DR_DU_Pos));
 
   MODIFY_REG(RTCx->DR, (RTC_DR_WDU | RTC_DR_MT | RTC_DR_MU | RTC_DR_DT | RTC_DR_DU | RTC_DR_YT | RTC_DR_YU), temp);


### PR DESCRIPTION
This patch can be applied to the all of STM32Cube series using LL_RTC_DATE_Config().